### PR TITLE
LoggingTranslator should implement Symfony\Contracts\Translation\TranslatorInterface

### DIFF
--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
  */
-class LoggingTranslator implements LegacyTranslatorInterface, TranslatorBagInterface
+class LoggingTranslator implements TranslatorInterface, LegacyTranslatorInterface, TranslatorBagInterface
 {
     /**
      * @var TranslatorInterface|TranslatorBagInterface


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #29089
| License       | MIT

While autowire Translator using `Symfony\Contracts\Translation\TranslatorInterface` symfony complains that wrong service was injected, because LoggingTranslator does not implement new interface.

